### PR TITLE
Refactor events and commands to use lighter-weight schema

### DIFF
--- a/src/marzoloco/wagering/commands.clj
+++ b/src/marzoloco/wagering/commands.clj
@@ -4,45 +4,45 @@
 ;; should there be a Wager value "object" here that is used by most commands?
 ;; I don't think so, because only the PlaceWager command needs the verbose Wager description
 
-(s/defrecord DepositPoints
-  [player-id :- s/Uuid
-   amount :- BigDecimal])
+(s/defschema DepositPoints {:command-type (s/eq :deposit-points)
+                            :player-id    s/Uuid
+                            :amount       s/Num})
 
-(s/defrecord PlaceWager
-  [player-id :- s/Uuid
-   wager-id :- s/Uuid
-   game-id :- s/Uuid
-   ; may not need game-id since it's implied by the bet-id
-   bet-id :- s/Uuid
-   side :- (s/enum :a :b)
-   ; looking for better language to generically describe the sides of a bet
-   odds :- BigDecimal
-   amount :- BigDecimal])
+(s/defschema PlaceWager {:command-type (s/eq :place-wager)
+                         :player-id    s/Uuid
+                         :wager-id     s/Uuid
+                         :game-id      s/Uuid
+                         ; may not need game-id since it's implied by the bet-id
+                         :bet-id       s/Uuid
+                         :side         (s/enum :a :b)
+                         ; looking for better language to generically describe the sides of a bet
+                         :odds         s/Num
+                         :amount       s/Num})
 
 ;; It's obvious that bet-id and side have to be in this command, but they're not currently
 ;; part of the player aggregate. Do they belong in that aggregate, or is there a different
 ;; aggregate that turns results into win/loss for a given wager?
 
-(s/defrecord WithdrawWager
-  [player-id :- s/Uuid
-   wager-id :- s/Uuid])
+(s/defschema WithdrawWager {:command-type (s/eq :withdraw-wager)
+                            :player-id    s/Uuid
+                            :wager-id     s/Uuid})
 
-(s/defrecord CancelWager
-  [player-id :- s/Uuid
-   wager-id :- s/Uuid])
+(s/defschema CancelWager {:command-type (s/eq :cancel-wager)
+                          :player-id    s/Uuid
+                          :wager-id     s/Uuid})
 
-(s/defrecord LockWager
-  [player-id :- s/Uuid
-   wager-id :- s/Uuid])
+(s/defschema LockWager {:command-type (s/eq :lock-wager)
+                        :player-id    s/Uuid
+                        :wager-id     s/Uuid})
 
-(s/defrecord CloseWonWager
-  [player-id :- s/Uuid
-   wager-id :- s/Uuid])
+(s/defschema CloseWonWager {:command-type (s/eq :close-won-wager)
+                            :player-id    s/Uuid
+                            :wager-id     s/Uuid})
 
-(s/defrecord ClosePushedWager
-  [player-id :- s/Uuid
-   wager-id :- s/Uuid])
+(s/defschema ClosePushedWager {:command-type (s/eq :close-pushed-wager)
+                               :player-id    s/Uuid
+                               :wager-id     s/Uuid})
 
-(s/defrecord CloseLostWager
-  [player-id :- s/Uuid
-   wager-id :- s/Uuid])
+(s/defschema CloseLostWager {:command-type (s/eq :close-lost-wager)
+                             :player-id    s/Uuid
+                             :wager-id     s/Uuid})

--- a/src/marzoloco/wagering/events.clj
+++ b/src/marzoloco/wagering/events.clj
@@ -1,37 +1,48 @@
 (ns marzoloco.wagering.events
   (:require [schema.core :as s]))
 
-(s/defrecord PointsDeposited [player-id :- s/Uuid
-                              amount :- BigDecimal])
+(s/defschema PointsDeposited {:event-type (s/eq :points-deposited)
+                              :player-id  s/Uuid
+                              :amount     s/Num})
 
-(s/defrecord WagerPlaced [player-id :- s/Uuid
-                          wager-id :- s/Uuid
-                          amount :- BigDecimal
-                          odds :- BigDecimal])
+(s/defschema WagerPlaced {:event-type (s/eq :wager-placed)
+                          :player-id  s/Uuid
+                          :wager-id   s/Uuid
+                          :amount     s/Num
+                          :odds       s/Num})
 
-(s/defrecord OverdrawAttempted [player-id :- s/Uuid
-                                wager-id :- s/Uuid])
+(s/defschema OverdrawAttempted {:event-type (s/eq :overdraw-attempted)
+                                :player-id  s/Uuid
+                                :wager-id   s/Uuid})
 
-(s/defrecord WagerWithdrawn [player-id :- s/Uuid
-                             wager-id :- s/Uuid])
+(s/defschema WagerWithdrawn {:event-type (s/eq :wager-withdrawn)
+                             :player-id  s/Uuid
+                             :wager-id   s/Uuid})
 
-(s/defrecord LockedWagerWithdrawAttempted [player-id :- s/Uuid
-                                           wager-id :- s/Uuid])
+(s/defschema LockedWagerWithdrawAttempted {:event-type (s/eq :locked-wager-withdraw-attempted)
+                                           :player-id  s/Uuid
+                                           :wager-id   s/Uuid})
 
-(s/defrecord WagerCancelled [player-id :- s/Uuid
-                             wager-id :- s/Uuid])
+(s/defschema WagerCancelled {:event-type (s/eq :wager-cancelled)
+                             :player-id  s/Uuid
+                             :wager-id   s/Uuid})
 
-(s/defrecord WagerLocked [player-id :- s/Uuid
-                          wager-id :- s/Uuid])
+(s/defschema WagerLocked {:event-type (s/eq :wager-locked)
+                          :player-id  s/Uuid
+                          :wager-id   s/Uuid})
 
-(s/defrecord WagerWon [player-id :- s/Uuid
-                       wager-id :- s/Uuid])
+(s/defschema WagerWon {:event-type (s/eq :wager-won)
+                       :player-id  s/Uuid
+                       :wager-id   s/Uuid})
 
-(s/defrecord WagerPushed [player-id :- s/Uuid
-                          wager-id :- s/Uuid])
+(s/defschema WagerPushed {:event-type (s/eq :wager-pushed)
+                          :player-id  s/Uuid
+                          :wager-id   s/Uuid})
 
-(s/defrecord WagerLost [player-id :- s/Uuid
-                        wager-id :- s/Uuid])
+(s/defschema WagerLost {:event-type (s/eq :wager-lost)
+                        :player-id  s/Uuid
+                        :wager-id   s/Uuid})
 
-(s/defrecord WinningsEarned [player-id :- s/Uuid
-                             amount :- BigDecimal])
+(s/defschema WinningsEarned {:event-type (s/eq :winnings-earned)
+                             :player-id  s/Uuid
+                             :amount     s/Num})

--- a/test/marzoloco/wagering/player_test.clj
+++ b/test/marzoloco/wagering/player_test.clj
@@ -12,13 +12,14 @@
 
 (deftest apply-PointsDeposited-event
   (let [player-id (uuid)
-        initial-bankroll 0.0M
-        deposited-amount 200.0M
+        initial-bankroll 0.0
+        deposited-amount 200.0
         expected-bankroll (+ initial-bankroll deposited-amount)
         initial-player (map->Player {:player-id player-id
                                      :bankroll  initial-bankroll})
-        points-deposited-event (e/map->PointsDeposited {:player-id player-id
-                                                        :amount    deposited-amount})
+        points-deposited-event {:event-type :points-deposited
+                                :player-id  player-id
+                                :amount     deposited-amount}
         expected-player (map->Player {:player-id player-id
                                       :bankroll  expected-bankroll})
         actual-player (apply-event initial-player points-deposited-event)]
@@ -26,19 +27,20 @@
 
 (deftest apply-WagerPlaced-event
   (let [player-id (uuid)
-        initial-bankroll 200.0M
-        other-wager (map->Wager {:wager-id (uuid) :amount 12.34M :odds 2.0M :locked? false})
+        initial-bankroll 200.0
+        other-wager (map->Wager {:wager-id (uuid) :amount 12.34 :odds 2.0 :locked? false})
         initial-open-wagers #{other-wager}
-        placed-wager (map->Wager {:wager-id (uuid) :amount 23.45M :odds 2.0M :locked? false})
+        placed-wager (map->Wager {:wager-id (uuid) :amount 23.45 :odds 2.0 :locked? false})
         expected-bankroll (- initial-bankroll (:amount placed-wager))
         expected-open-wagers #{placed-wager other-wager}
         initial-player (map->Player {:player-id   player-id
                                      :open-wagers initial-open-wagers
                                      :bankroll    initial-bankroll})
-        wager-placed-event (e/map->WagerPlaced {:player-id player-id
-                                                :wager-id  (:wager-id placed-wager)
-                                                :amount    (:amount placed-wager)
-                                                :odds      2.0M})
+        wager-placed-event {:event-type :wager-placed
+                            :player-id  player-id
+                            :wager-id   (:wager-id placed-wager)
+                            :amount     (:amount placed-wager)
+                            :odds       2.0}
         expected-player (map->Player {:player-id   player-id
                                       :bankroll    expected-bankroll
                                       :open-wagers expected-open-wagers})
@@ -47,8 +49,8 @@
 
 (deftest apply-WagerWithdrawnCancelled-event
   (let [player-id (uuid)
-        initial-bankroll 150.0M
-        wager (map->Wager {:wager-id (uuid) :amount 50.0M :locked? false})
+        initial-bankroll 150.0
+        wager (map->Wager {:wager-id (uuid) :amount 50.0 :locked? false})
         initial-open-wagers #{wager}
         expected-bankroll (+ initial-bankroll (:amount wager))
         expected-open-wagers #{}
@@ -59,28 +61,31 @@
                                       :bankroll    expected-bankroll
                                       :open-wagers expected-open-wagers})]
     (testing "WagerWithdrawn increases bankroll and removes wager from open-wagers"
-      (let [wager-withdrawn-event (e/map->WagerWithdrawn {:player-id player-id
-                                                          :wager-id  (:wager-id wager)})
+      (let [wager-withdrawn-event {:event-type :wager-withdrawn
+                                   :player-id  player-id
+                                   :wager-id   (:wager-id wager)}
             actual-player (apply-event initial-player wager-withdrawn-event)]
         (is (= expected-player actual-player))))
     (testing "WagerCancelled increases bankroll and removes wager from open-wagers"
-      (let [wager-cancelled-event (e/map->WagerCancelled {:player-id player-id
-                                                          :wager-id  (:wager-id wager)})
+      (let [wager-cancelled-event {:event-type :wager-cancelled
+                                   :player-id  player-id
+                                   :wager-id   (:wager-id wager)}
             actual-player (apply-event initial-player wager-cancelled-event)]
         (is (= expected-player actual-player))))))
 
 (deftest apply-WagerLocked-event
   (let [player-id (uuid)
-        wager (map->Wager {:wager-id (uuid) :amount 50.0M :locked? false})
+        wager (map->Wager {:wager-id (uuid) :amount 50.0 :locked? false})
         wager-id (:wager-id wager)
-        other-wager (map->Wager {:wager-id (uuid) :amount 100.0M :locked? false})
+        other-wager (map->Wager {:wager-id (uuid) :amount 100.0 :locked? false})
         initial-open-wagers #{wager other-wager}
         expected-wager (assoc wager :locked? true)
         expected-open-wagers #{expected-wager other-wager}
         initial-player (map->Player {:player-id   player-id
                                      :open-wagers initial-open-wagers})
-        wager-locked-event (e/map->WagerLocked {:player-id player-id
-                                                :wager-id  wager-id})
+        wager-locked-event {:event-type :wager-locked
+                            :player-id  player-id
+                            :wager-id   wager-id}
         expected-player (map->Player {:player-id   player-id
                                       :open-wagers expected-open-wagers})
         actual-player (apply-event initial-player wager-locked-event)]
@@ -88,9 +93,9 @@
 
 (deftest apply-WagerWonPushedLost-event
   (let [player-id (uuid)
-        wager (map->Wager {:wager-id (uuid) :amount 23.45M :locked? true})
+        wager (map->Wager {:wager-id (uuid) :amount 23.45 :locked? true})
         wager-id (:wager-id wager)
-        other-wager (map->Wager {:wager-id (uuid) :amount 12.34M :locked? false})
+        other-wager (map->Wager {:wager-id (uuid) :amount 12.34 :locked? false})
         initial-open-wagers #{other-wager wager}
         expected-open-wagers #{other-wager}
         initial-player (map->Player {:player-id   player-id
@@ -98,27 +103,31 @@
         expected-player (map->Player {:player-id   player-id
                                       :open-wagers expected-open-wagers})]
     (testing "WagerWon event removes wager from open-wagers"
-      (let [wager-won-event (e/map->WagerWon {:player-id player-id
-                                              :wager-id  wager-id})
+      (let [wager-won-event {:event-type :wager-won
+                             :player-id  player-id
+                             :wager-id   wager-id}
             actual-player (apply-event initial-player wager-won-event)]
         (is (= expected-player actual-player))))
     (testing "WagerPushed event removes wager from open-wagers"
-      (let [wager-pushed-event (e/map->WagerPushed {:player-id player-id
-                                                    :wager-id  wager-id})
+      (let [wager-pushed-event {:event-type :wager-pushed
+                                :player-id  player-id
+                                :wager-id   wager-id}
             actual-player (apply-event initial-player wager-pushed-event)]
         (is (= expected-player actual-player))))
     (testing "WagerLost event removes wager from open-wagers"
-      (let [wager-lost-event (e/map->WagerLost {:player-id player-id
-                                                :wager-id  wager-id})
+      (let [wager-lost-event {:event-type :wager-lost
+                              :player-id  player-id
+                              :wager-id   wager-id}
             actual-player (apply-event initial-player wager-lost-event)]
         (is (= expected-player actual-player))))))
 
 (deftest apply-WinningsEarned-event
   (let [player-id (uuid)
-        earned-amount 50.0M
+        earned-amount 50.0
         initial-player (map->Player {:player-id player-id})
-        winnings-earned-event (e/map->WinningsEarned {:player-id player-id
-                                                      :amount    earned-amount})
+        winnings-earned-event {:event-type :winnings-earned
+                               :player-id  player-id
+                               :amount     earned-amount}
         expected-player (map->Player {:player-id player-id})
         actual-player (apply-event initial-player winnings-earned-event)]
     (is (= expected-player actual-player))))
@@ -128,102 +137,113 @@
   (let [player-id (uuid)
         player (map->Player {:player-id player-id})]
     (testing "DepositPoints -> PointsDeposited"
-      (let [deposited-amount 200.00M
-            depositPoints-cmd (c/map->DepositPoints {:player-id player-id
-                                                     :amount    deposited-amount})
-            expected-events [(e/map->PointsDeposited {:player-id player-id
-                                                      :amount    deposited-amount})]
+      (let [deposited-amount 200.00
+            depositPoints-cmd {:command-type :deposit-points
+                               :player-id    player-id
+                               :amount       deposited-amount}
+            expected-events [{:event-type :points-deposited
+                              :player-id  player-id
+                              :amount     deposited-amount}]
             actual-events (execute-command player depositPoints-cmd)]
         (is (= expected-events actual-events))))))
 
 (deftest execute-PlaceWager-command
   (let [player-id (uuid)
-        bankroll 123.45M
+        bankroll 123.45
         player (map->Player {:player-id player-id
                              :bankroll  bankroll})
         wager-id (uuid)
-        odds 3.0M
-        base-placeWager-cmd (c/map->PlaceWager {:player-id player-id
-                                                :wager-id  wager-id
-                                                :game-id   (uuid)
-                                                :bet-id    (uuid)
-                                                :side      :a
-                                                :odds      odds})]
+        odds 3.0
+        base-placeWager-cmd {:command-type :place-wager
+                             :player-id    player-id
+                             :wager-id     wager-id
+                             :game-id      (uuid)
+                             :bet-id       (uuid)
+                             :side         :a
+                             :odds         odds}]
     (testing "PlaceWager for less than bankroll -> WagerPlaced"
       (let [wager-amount (/ bankroll 2)
             placeWager-cmd (assoc base-placeWager-cmd :amount wager-amount)
-            expected-events [(e/map->WagerPlaced {:player-id player-id
-                                                  :wager-id  wager-id
-                                                  :amount    wager-amount
-                                                  :odds      odds})]
+            expected-events [{:event-type :wager-placed
+                              :player-id  player-id
+                              :wager-id   wager-id
+                              :amount     wager-amount
+                              :odds       odds}]
             actual-events (execute-command player placeWager-cmd)]
         (is (= expected-events actual-events))))
     (testing "PlaceWager for entire bankroll -> WagerPlaced"
       (let [wager-amount bankroll
             placeWager-cmd (assoc base-placeWager-cmd :amount wager-amount)
-            expected-events [(e/map->WagerPlaced {:player-id player-id
-                                                  :wager-id  wager-id
-                                                  :amount    wager-amount
-                                                  :odds      odds})]
+            expected-events [{:event-type :wager-placed
+                              :player-id  player-id
+                              :wager-id   wager-id
+                              :amount     wager-amount
+                              :odds       odds}]
             actual-events (execute-command player placeWager-cmd)]
         (is (= expected-events actual-events))))
     (testing "PlaceWager over bankroll -> OverdrawAttempted"
       (let [wager-amount (* bankroll 2)
             placeWager-cmd (assoc base-placeWager-cmd :amount wager-amount)
-            expected-events [(e/map->OverdrawAttempted {:player-id player-id
-                                                        :wager-id  wager-id})]
+            expected-events [{:event-type :overdraw-attempted
+                              :player-id  player-id
+                              :wager-id   wager-id}]
             actual-events (execute-command player placeWager-cmd)]
         (is (= expected-events actual-events))))))
 
 (deftest execute-WithdrawWager-command
   (let [player-id (uuid)
-        bankroll 123.45M
+        bankroll 123.45
         wager-id (uuid)
         other-wager (map->Wager {:wager-id (uuid)
-                                 :amount   25.0M
+                                 :amount   25.0
                                  :locked?  false})
-        withdrawWager-cmd (c/map->WithdrawWager {:player-id player-id
-                                                 :wager-id  wager-id})]
+        withdrawWager-cmd {:command-type :withdraw-wager
+                           :player-id    player-id
+                           :wager-id     wager-id}]
     (testing "WithdrawWager on not locked wager -> WagerWithdrawn"
       (let [wager (map->Wager {:wager-id wager-id
-                               :amount   50.0M
+                               :amount   50.0
                                :locked?  false})
             player (map->Player {:player-id   player-id
                                  :bankroll    bankroll
                                  :open-wagers #{wager other-wager}})
-            expected-events [(e/map->WagerWithdrawn {:player-id player-id
-                                                     :wager-id  wager-id})]
+            expected-events [{:event-type :wager-withdrawn
+                              :player-id  player-id
+                              :wager-id   wager-id}]
             actual-events (execute-command player withdrawWager-cmd)]
         (is (= expected-events actual-events))))
     (testing "WithdrawWager on locked wager -> LockedWagerWithdrawAttempted"
       (let [wager (map->Wager {:wager-id wager-id
-                               :amount   50.0M
+                               :amount   50.0
                                :locked?  true})
             player (map->Player {:player-id   player-id
                                  :bankroll    bankroll
                                  :open-wagers #{wager other-wager}})
-            expected-events [(e/map->LockedWagerWithdrawAttempted {:player-id player-id
-                                                                   :wager-id  wager-id})]
+            expected-events [{:event-type :locked-wager-withdraw-attempted
+                              :player-id  player-id
+                              :wager-id   wager-id}]
             actual-events (execute-command player withdrawWager-cmd)]
         (is (= expected-events actual-events))))))
 
 (deftest execute-CancelWager-command
   (let [player-id (uuid)
-        bankroll 123.45M
+        bankroll 123.45
         wager-id (uuid)
         wager (map->Wager {:wager-id wager-id
-                           :amount   50.0M
+                           :amount   50.0
                            :locked?  false})
         other-wager (map->Wager {:wager-id (uuid)
-                                 :amount   25.0M
+                                 :amount   25.0
                                  :locked?  false})
         player (map->Player {:player-id   player-id
                              :bankroll    bankroll
                              :open-wagers #{wager other-wager}})
-        cancelWager-cmd (c/map->CancelWager {:player-id player-id
-                                             :wager-id  wager-id})
-        expected-events [(e/map->WagerCancelled {:player-id player-id
-                                                 :wager-id  wager-id})]
+        cancelWager-cmd {:command-type :cancel-wager
+                         :player-id    player-id
+                         :wager-id     wager-id}
+        expected-events [{:event-type :wager-cancelled
+                          :player-id  player-id
+                          :wager-id   wager-id}]
         actual-events (execute-command player cancelWager-cmd)]
     (is (= expected-events actual-events))))
 
@@ -231,54 +251,64 @@
   (let [player-id (uuid)
         wager-id (uuid)
         wager (map->Wager {:wager-id wager-id
-                           :amount   50.0M
+                           :amount   50.0
                            :locked?  false})
         other-wager (map->Wager {:wager-id (uuid)
-                                 :amount   25.0M
+                                 :amount   25.0
                                  :locked?  false})
         player (map->Player {:player-id   player-id
                              :open-wagers #{wager other-wager}})
-        lockWager-cmd (c/map->LockWager {:player-id player-id
-                                         :wager-id  wager-id})
-        expected-events [(e/map->WagerLocked {:player-id player-id
-                                              :wager-id  wager-id})]
+        lockWager-cmd {:command-type :lock-wager
+                       :player-id    player-id
+                       :wager-id     wager-id}
+        expected-events [{:event-type :wager-locked
+                          :player-id  player-id
+                          :wager-id   wager-id}]
         actual-events (execute-command player lockWager-cmd)]
     (is (= expected-events actual-events))))
 
 (deftest execute-CloseWonPushedLostWager-command
   (let [player-id (uuid)
         wager-id (uuid)
-        wager-amount 50.0M
-        odds 3.0M
-        expected-winnings 150.0M
-        expected-push-winnings 50.0M
+        wager-amount 50.0
+        odds 3.0
+        expected-winnings 150.0
+        expected-push-winnings 50.0
         wager (map->Wager {:wager-id wager-id
                            :amount   wager-amount
                            :odds     odds})
         player (map->Player {:player-id   player-id
                              :open-wagers #{wager}})]
     (testing "CloseWonWager -> WagerWon and WinningsEarned"
-      (let [closeWonWager-cmd (c/map->CloseWonWager {:player-id player-id
-                                                     :wager-id  wager-id})
-            expected-events [(e/map->WagerWon {:player-id player-id
-                                               :wager-id  wager-id})
-                             (e/map->WinningsEarned {:player-id player-id
-                                                     :amount    expected-winnings})]
+      (let [closeWonWager-cmd {:command-type :close-won-wager
+                               :player-id    player-id
+                               :wager-id     wager-id}
+            expected-events [{:event-type :wager-won
+                              :player-id  player-id
+                              :wager-id   wager-id}
+                             {:event-type :winnings-earned
+                              :player-id  player-id
+                              :amount     expected-winnings}]
             actual-events (execute-command player closeWonWager-cmd)]
         (is (= expected-events actual-events))))
     (testing "ClosePushedWager -> WagerPushed and WinningsEarned"
-      (let [closePushedWager-cmd (c/map->ClosePushedWager {:player-id player-id
-                                                           :wager-id  wager-id})
-            expected-events [(e/map->WagerPushed {:player-id player-id
-                                                  :wager-id  wager-id})
-                             (e/map->WinningsEarned {:player-id player-id
-                                                     :amount    expected-push-winnings})]
+      (let [closePushedWager-cmd {:command-type :close-pushed-wager
+                                  :player-id    player-id
+                                  :wager-id     wager-id}
+            expected-events [{:event-type :wager-pushed
+                              :player-id  player-id
+                              :wager-id   wager-id}
+                             {:event-type :winnings-earned
+                              :player-id  player-id
+                              :amount     expected-push-winnings}]
             actual-events (execute-command player closePushedWager-cmd)]
         (is (= expected-events actual-events))))
     (testing "CloseLostWager -> WagerLost"
-      (let [closeLostWager-cmd (c/map->CloseLostWager {:player-id player-id
-                                                       :wager-id  wager-id})
-            expected-events [(e/map->WagerLost {:player-id player-id
-                                                :wager-id  wager-id})]
+      (let [closeLostWager-cmd {:command-type :close-lost-wager
+                                :player-id    player-id
+                                :wager-id     wager-id}
+            expected-events [{:event-type :wager-lost
+                              :player-id  player-id
+                              :wager-id   wager-id}]
             actual-events (execute-command player closeLostWager-cmd)]
         (is (= expected-events actual-events))))))


### PR DESCRIPTION
Using a lighter-weight approach to declaring the schema of the commands and events that happens to work better with ring-swagger.
Using s/Num instead of BigDecimal since I can't easily pass a BigDecimal in JSON.